### PR TITLE
Initial changes for JSON columns

### DIFF
--- a/src/Searchlight/Attributes/SearchlightField.cs
+++ b/src/Searchlight/Attributes/SearchlightField.cs
@@ -32,5 +32,10 @@ namespace Searchlight
         /// (optional) If you wish to use Searchlight autocomplete, you can provide a documentation block here.
         /// </summary>
         public string Description { get; set; }
+        
+        /// <summary>
+        /// (optional) Set to true if the database column is storing JSON.
+        /// </summary>
+        public bool IsJson { get; set; } = false;
     }
 }

--- a/src/Searchlight/Attributes/SearchlightField.cs
+++ b/src/Searchlight/Attributes/SearchlightField.cs
@@ -35,6 +35,13 @@ namespace Searchlight
         
         /// <summary>
         /// (optional) Set to true if the database column is storing JSON.
+        ///
+        /// Current limitations of using JSON columns include:
+        /// - No filtering/sorting on JSON arrays
+        /// - Supported operators are:
+        ///   - (Not) Equals
+        ///   - (Not) In
+        ///   - Is (Not) Null
         /// </summary>
         public bool IsJson { get; set; } = false;
     }

--- a/src/Searchlight/DataSource.cs
+++ b/src/Searchlight/DataSource.cs
@@ -65,15 +65,15 @@ namespace Searchlight
         /// <returns></returns>
         public DataSource WithColumn(string columnName, Type columnType)
         {
-            return WithRenamingColumn(columnName, columnName, null, columnType, null, null);
+            return WithRenamingColumn(columnName, columnName, null, columnType, null, null, false);
         }
 
         /// <summary>
         /// Add a column to this definition
         /// </summary>
-        public DataSource WithRenamingColumn(string filterName, string columnName, string[] aliases, Type columnType, Type enumType, string description)
+        public DataSource WithRenamingColumn(string filterName, string columnName, string[] aliases, Type columnType, Type enumType, string description, bool isJson)
         {
-            var columnInfo = new ColumnInfo(filterName, columnName, aliases, columnType, enumType, description);
+            var columnInfo = new ColumnInfo(filterName, columnName, aliases, columnType, enumType, description, isJson);
             _columns.Add(columnInfo);
 
             // Allow the API caller to either specify either the model name or one of the aliases
@@ -203,7 +203,7 @@ namespace Searchlight
                             var t = filter.FieldType ?? pi.PropertyType;
                             var columnName = filter.OriginalName ?? pi.Name;
                             var aliases = filter.Aliases ?? Array.Empty<string>();
-                            src.WithRenamingColumn(pi.Name, columnName, aliases, t, filter.EnumType, filter.Description);
+                            src.WithRenamingColumn(pi.Name, columnName, aliases, t, filter.EnumType, filter.Description, filter.IsJson);
                         }
 
                         var collection = pi.GetCustomAttributes<SearchlightCollection>().FirstOrDefault();

--- a/src/Searchlight/DataSource.cs
+++ b/src/Searchlight/DataSource.cs
@@ -65,22 +65,21 @@ namespace Searchlight
         /// <returns></returns>
         public DataSource WithColumn(string columnName, Type columnType)
         {
-            return WithRenamingColumn(columnName, columnName, null, columnType, null, null, false);
+            return WithRenamingColumn(new ColumnInfo(columnName, columnName, null, columnType, null, null, false));
         }
 
         /// <summary>
         /// Add a column to this definition
         /// </summary>
-        public DataSource WithRenamingColumn(string filterName, string columnName, string[] aliases, Type columnType, Type enumType, string description, bool isJson)
+        public DataSource WithRenamingColumn(ColumnInfo columnInfo)
         {
-            var columnInfo = new ColumnInfo(filterName, columnName, aliases, columnType, enumType, description, isJson);
             _columns.Add(columnInfo);
 
             // Allow the API caller to either specify either the model name or one of the aliases
-            AddName(filterName, columnInfo);
-            if (aliases != null)
+            AddName(columnInfo.FieldName, columnInfo);
+            if (columnInfo.Aliases != null)
             {
-                foreach (var alias in aliases)
+                foreach (var alias in columnInfo.Aliases)
                 {
                     AddName(alias, columnInfo);
                 }
@@ -203,7 +202,7 @@ namespace Searchlight
                             var t = filter.FieldType ?? pi.PropertyType;
                             var columnName = filter.OriginalName ?? pi.Name;
                             var aliases = filter.Aliases ?? Array.Empty<string>();
-                            src.WithRenamingColumn(pi.Name, columnName, aliases, t, filter.EnumType, filter.Description, filter.IsJson);
+                            src.WithRenamingColumn(new ColumnInfo(pi.Name, columnName, aliases, t, filter.EnumType, filter.Description, filter.IsJson));
                         }
 
                         var collection = pi.GetCustomAttributes<SearchlightCollection>().FirstOrDefault();

--- a/src/Searchlight/Exceptions/UnterminatedJsonKey.cs
+++ b/src/Searchlight/Exceptions/UnterminatedJsonKey.cs
@@ -1,0 +1,28 @@
+﻿#pragma warning disable CS1591
+namespace Searchlight
+{
+    /// <summary>
+    /// A filter statement contained an unterminated JSON key.  An opening double quote was observed but the remainder
+    /// of the string did not contain a closing quote.
+    ///
+    /// Example: (dimensions."address is not null)
+    /// </summary>
+    public class UnterminatedJsonKey : SearchlightException
+    {
+        public string OriginalFilter { get; internal set; }
+        public int StartPosition { get; internal set; }
+        public ParsingType ParsingType { get; internal set; }
+
+        public string ErrorMessage
+        {
+            get =>
+                $"The query {(ParsingType == ParsingType.Filter ? "filter" : "order by")}, {OriginalFilter}, contained an unterminated JSON Key that starts at {StartPosition}. JSON Keys should be in the format .\"{{KeyName}}\"";
+        }
+    }
+
+    public enum ParsingType
+    {
+        Filter,
+        OrderBy
+    }
+}

--- a/src/Searchlight/Parsing/ColumnInfo.cs
+++ b/src/Searchlight/Parsing/ColumnInfo.cs
@@ -16,7 +16,8 @@ namespace Searchlight.Parsing
         /// <param name="columnType">The raw type of the column in the database</param>
         /// <param name="enumType">The type of the enum that the column is mapped to</param>
         /// <param name="description">A description of the column for autocomplete</param>
-        public ColumnInfo(string filterName, string columnName, string[] aliases, Type columnType, Type enumType, string description)
+        /// <param name="isJson"></param>
+        public ColumnInfo(string filterName, string columnName, string[] aliases, Type columnType, Type enumType, string description, bool isJson)
         {
             FieldName = filterName;
             OriginalName = columnName;
@@ -29,6 +30,7 @@ namespace Searchlight.Parsing
 
             EnumType = enumType;
             Description = description;
+            IsJson = isJson;
         }
 
         /// <summary>
@@ -61,5 +63,10 @@ namespace Searchlight.Parsing
         /// Detailed field documentation for autocomplete, if provided.
         /// </summary>
         public string Description { get; private set; }
+
+        /// <summary>
+        /// (optional) Set to true if the database column is storing JSON.
+        /// </summary>
+        public bool IsJson { get; set; } = false;
     }
 }

--- a/src/Searchlight/Parsing/SyntaxParser.cs
+++ b/src/Searchlight/Parsing/SyntaxParser.cs
@@ -173,7 +173,7 @@ namespace Searchlight.Parsing
                         FieldName = colName.Value, KnownFields = source.ColumnNames().ToArray(), OriginalFilter = orderBy
                     });
                 }
-                
+
                 // Was that the last token?
                 if (tokens.TokenQueue.Count == 0) break;
                 
@@ -456,7 +456,7 @@ namespace Searchlight.Parsing
 
                 // Safe syntax for an "IS NULL" expression is "column IS [NOT] NULL"
                 case OperationType.IsNull:
-                    var iN = new IsNullClause { Column = columnInfo };
+                    var isNull = new IsNullClause { Column = columnInfo };
 
                     // Allow "not" to come either before or after the "IS"
                     var next = tokens.TokenQueue.Dequeue().Value.ToUpperInvariant();
@@ -466,10 +466,10 @@ namespace Searchlight.Parsing
                         next = tokens.TokenQueue.Dequeue().Value;
                     }
 
-                    iN.Negated = negated;
-                    iN.JsonKeys = jsonKeys.ToArray();
+                    isNull.Negated = negated;
+                    isNull.JsonKeys = jsonKeys.ToArray();
                     syntax.Expect(StringConstants.NULL, next, tokens.OriginalText);
-                    return iN;
+                    return isNull;
 
                 // Safe syntax for all other recognized expressions is "column op param"
                 default:

--- a/src/Searchlight/Parsing/TokenStream.cs
+++ b/src/Searchlight/Parsing/TokenStream.cs
@@ -23,7 +23,7 @@ namespace Searchlight.Parsing
         public bool HasUnterminatedLiteral { get; set; }
         
         /// <summary>
-        /// Set to true if there is an open double quote but no close double quote
+        /// Set to true if there is an open double quote but no closing double quote
         /// </summary>
         public bool HasUnterminatedJsonKeyName { get; set; }
         

--- a/src/Searchlight/Parsing/TokenStream.cs
+++ b/src/Searchlight/Parsing/TokenStream.cs
@@ -23,8 +23,18 @@ namespace Searchlight.Parsing
         public bool HasUnterminatedLiteral { get; set; }
         
         /// <summary>
+        /// Set to true if there is an open double quote but no close double quote
+        /// </summary>
+        public bool HasUnterminatedJsonKeyName { get; set; }
+        
+        /// <summary>
         /// Used to determine where unterminated literal begins
         /// </summary>
         public int LastStringLiteralBegin { get; set; }
+        
+        /// <summary>
+        /// Used to determine where JSON Key begins
+        /// </summary>
+        public int LastJsonKeyBegin { get; set; }
     }
 }

--- a/src/Searchlight/Query/BaseClause.cs
+++ b/src/Searchlight/Query/BaseClause.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using Searchlight.Parsing;
 
 namespace Searchlight.Query

--- a/src/Searchlight/Query/BaseClause.cs
+++ b/src/Searchlight/Query/BaseClause.cs
@@ -1,4 +1,7 @@
 ﻿
+using System;
+using Searchlight.Parsing;
+
 namespace Searchlight.Query
 {
     /// <summary>
@@ -6,6 +9,11 @@ namespace Searchlight.Query
     /// </summary>
     public class BaseClause
     {
+        /// <summary>
+        /// The field being tested
+        /// </summary>
+        public ColumnInfo Column { get; set; }
+        
         /// <summary>
         /// This value is true if the result of this test is to be inverted
         /// </summary>
@@ -16,5 +24,10 @@ namespace Searchlight.Query
         /// If this is the last clause, the conjunction is NONE.
         /// </summary>
         public ConjunctionType Conjunction { get; set; }
+
+        /// <summary>
+        /// List of all JSON keys that are being filtered on for this clause
+        /// </summary>
+        public string[] JsonKeys { get; set; } = Array.Empty<string>();
     }
 }

--- a/src/Searchlight/Query/BetweenClause.cs
+++ b/src/Searchlight/Query/BetweenClause.cs
@@ -9,11 +9,6 @@ namespace Searchlight.Query
     public class BetweenClause : BaseClause
     {
         /// <summary>
-        /// The field being tested
-        /// </summary>
-        public ColumnInfo Column { get; set; }
-
-        /// <summary>
         /// Lower value in the between test
         /// </summary>
         public IExpressionValue LowerValue { get; set; }

--- a/src/Searchlight/Query/CriteriaClause.cs
+++ b/src/Searchlight/Query/CriteriaClause.cs
@@ -9,11 +9,6 @@ namespace Searchlight.Query
     public class CriteriaClause : BaseClause
     {
         /// <summary>
-        /// The field being tested
-        /// </summary>
-        public ColumnInfo Column { get; set; }
-
-        /// <summary>
         /// Operation for testing
         /// </summary>
         public OperationType Operation { get; set; }

--- a/src/Searchlight/Query/InClause.cs
+++ b/src/Searchlight/Query/InClause.cs
@@ -10,11 +10,6 @@ namespace Searchlight.Query
     public class InClause : BaseClause
     {
         /// <summary>
-        /// The field to test
-        /// </summary>
-        public ColumnInfo Column { get; set; }
-
-        /// <summary>
         /// The list of values to test against
         /// </summary>
         public List<IExpressionValue> Values { get; set; }

--- a/src/Searchlight/Query/IsNullClause.cs
+++ b/src/Searchlight/Query/IsNullClause.cs
@@ -8,11 +8,6 @@ namespace Searchlight.Query
     public class IsNullClause : BaseClause
     {
         /// <summary>
-        /// The field being tested
-        /// </summary>
-        public ColumnInfo Column { get; set; }
-        
-        /// <summary>
         /// Render this criteria in a readable string
         /// </summary>
         public override string ToString()

--- a/src/Searchlight/Query/SortInfo.cs
+++ b/src/Searchlight/Query/SortInfo.cs
@@ -1,3 +1,4 @@
+using System;
 using Searchlight.Parsing;
 
 namespace Searchlight.Query
@@ -17,6 +18,11 @@ namespace Searchlight.Query
         /// </summary>
         public SortDirection Direction { get; set; }
 
+        /// <summary>
+        /// An array of JSON keys for the sort if any.
+        /// </summary>
+        public string[] JsonKeys { get; set; } = Array.Empty<string>();
+        
         /// <summary>
         /// Convenience to return the abbreviated string for directions
         /// </summary>

--- a/src/Searchlight/Query/SyntaxTree.cs
+++ b/src/Searchlight/Query/SyntaxTree.cs
@@ -32,7 +32,7 @@ namespace Searchlight.Query
         /// <returns>True if this flag is enabled</returns>
         public bool HasFlag(string flagName)
         {
-            return (from f in Flags where String.Equals(f.Name, flagName, StringComparison.CurrentCultureIgnoreCase) select f).Any();
+            return (from f in Flags where string.Equals(f.Name, flagName, StringComparison.CurrentCultureIgnoreCase) select f).Any();
         }
 
         /// <summary>

--- a/src/Searchlight/StringConstants.cs
+++ b/src/Searchlight/StringConstants.cs
@@ -81,6 +81,11 @@ namespace Searchlight
         public static readonly char SINGLE_QUOTE = '\'';
 
         /// <summary>
+        /// Represents a double quote character for tokenization of JSON key names
+        /// </summary>
+        public static readonly char DOUBLE_QUOTE = '"';
+
+        /// <summary>
         /// Represents an open parenthesis character for tokenization of strings
         /// </summary>
         public static readonly string OPEN_PARENTHESIS = "(";
@@ -136,6 +141,16 @@ namespace Searchlight
         /// Used for date math
         /// </summary>
         public static readonly string SUBTRACT = "-";
+
+        /// <summary>
+        /// Used to start JSON keys 
+        /// </summary>
+        public static readonly char DOT = '.';
+
+        /// <summary>
+        /// Used for escape characters 
+        /// </summary>
+        public static readonly char BACKSLASH = '\\';
 
         /// <summary>
         /// Used as shorthand for typing today's date

--- a/tests/Searchlight.Tests/Executors/SqlServerExecutorTests.cs
+++ b/tests/Searchlight.Tests/Executors/SqlServerExecutorTests.cs
@@ -98,7 +98,6 @@ public class SqlServerExecutorTests
                                 paycheck = reader.GetDecimal("paycheck"),
                                 onduty = reader.GetBoolean("onduty"),
                                 employeeType = (EmployeeObj.EmployeeType)reader.GetInt32(5),
-                                dims = JsonConvert.DeserializeObject<Dictionary<string, object>>(reader.GetString("dims")),
                             });
                         }
                     }

--- a/tests/Searchlight.Tests/Executors/SqlServerExecutorTests.cs
+++ b/tests/Searchlight.Tests/Executors/SqlServerExecutorTests.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using Searchlight.Query;
 using Searchlight.Tests.Models;
 using Testcontainers.MsSql;
@@ -15,72 +16,68 @@ public class SqlServerExecutorTests
 {
     private DataSource _src;
     private string _connectionString;
-    private Func<SyntaxTree, Task<FetchResult<EmployeeObj>>> _postgres;
+    private Func<SyntaxTree, Task<FetchResult<EmployeeObj>>> _sqlServer;
     private List<EmployeeObj> _list;
     private MsSqlContainer _container;
+
+    private const string CreateSql =
+        "CREATE TABLE employeeobj (name nvarchar(255) null, id int not null, hired datetime not null, paycheck decimal not null, onduty bit not null, employeetype int null DEFAULT 0, dims nvarchar(max) null)";
+
+    private const string InsertSql =
+        "INSERT INTO employeeobj (name, id, hired, paycheck, onduty, employeetype, dims) VALUES (@name, @id, @hired, @paycheck, @onduty, @employeetype, @dims)";
 
     [TestInitialize]
     public async Task SetupClient()
     {
         _src = DataSource.Create(null, typeof(EmployeeObj), AttributeMode.Strict);
-        _container = new MsSqlBuilder()
-            .Build();
+        _container = new MsSqlBuilder().Build();
         await _container.StartAsync();
         _connectionString = _container.GetConnectionString();
-        
+
         // Construct the database schema and insert some test data
-        using (var connection = new SqlConnection(_connectionString))
+        await using (var connection = new SqlConnection(_connectionString))
         {
             await connection.OpenAsync();
 
             // Create basic table
-            using (var command =
-                   new SqlCommand(
-                       "CREATE TABLE employeeobj (name nvarchar(255) null, id int not null, hired datetime not null, paycheck decimal not null, onduty bit not null, employeetype int null DEFAULT 0)",
-                       connection))
+            await using (var command = new SqlCommand(CreateSql, connection))
             {
                 await command.ExecuteNonQueryAsync();
             }
-            
+
             // Insert rows
             foreach (var record in EmployeeObj.GetTestList())
             {
-                using (var command = new SqlCommand("INSERT INTO employeeobj (name, id, hired, paycheck, onduty, employeetype) VALUES (@name, @id, @hired, @paycheck, @onduty, @employeetype)", connection))
-                {
-                    command.Parameters.AddWithValue("@name", (object)record.name ?? DBNull.Value);
-                    command.Parameters.AddWithValue("@id", record.id);
-                    command.Parameters.AddWithValue("@hired", record.hired);
-                    command.Parameters.AddWithValue("@paycheck", record.paycheck);
-                    command.Parameters.AddWithValue("@onduty", record.onduty);
-                    command.Parameters.AddWithValue("@employeetype", record.employeeType);
-                    await command.ExecuteNonQueryAsync();
-                }
+                await using var command = new SqlCommand(InsertSql, connection);
+                var json = JsonConvert.SerializeObject(record.dims);
+                command.Parameters.AddWithValue("@name", (object)record.name ?? DBNull.Value);
+                command.Parameters.AddWithValue("@id", record.id);
+                command.Parameters.AddWithValue("@hired", record.hired);
+                command.Parameters.AddWithValue("@paycheck", record.paycheck);
+                command.Parameters.AddWithValue("@onduty", record.onduty);
+                command.Parameters.AddWithValue("@employeetype", record.employeeType);
+                command.Parameters.AddWithValue("@dims", json == "null" ? DBNull.Value : json);
+                await command.ExecuteNonQueryAsync();
             }
         }
 
         // Keep track of the correct result expectations and execution process
         _list = EmployeeObj.GetTestList();
-        _postgres = async syntax =>
+        _sqlServer = async syntax =>
         {
             var sql = syntax.ToSqlServerCommand();
             var result = new List<EmployeeObj>();
-            int numResults = 0;
-            using (var connection = new SqlConnection(_connectionString))
+            var numResults = 0;
+            await using (var connection = new SqlConnection(_connectionString))
             {
                 await connection.OpenAsync();
-                using (var command = new SqlCommand(sql.CommandText, connection))
+                await using (var command = new SqlCommand(sql.CommandText, connection))
                 {
                     foreach (var p in sql.Parameters)
                     {
                         var type = sql.ParameterTypes[p.Key];
-                        if (type == typeof(DateTime))
-                        {
-                            command.Parameters.AddWithValue(p.Key, ((DateTime)p.Value).ToUniversalTime());
-                        }
-                        else
-                        {
-                            command.Parameters.AddWithValue(p.Key, p.Value);
-                        }
+                        command.Parameters.AddWithValue(p.Key,
+                            type == typeof(DateTime) ? ((DateTime)p.Value).ToUniversalTime() : p.Value);
                     }
 
                     try
@@ -88,7 +85,7 @@ public class SqlServerExecutorTests
                         var reader = await command.ExecuteReaderAsync();
                         await reader.ReadAsync();
                         numResults = reader.GetInt32(0);
-                        
+
                         // Skip ahead to next result set
                         await reader.NextResultAsync();
                         while (await reader.ReadAsync())
@@ -101,6 +98,7 @@ public class SqlServerExecutorTests
                                 paycheck = reader.GetDecimal("paycheck"),
                                 onduty = reader.GetBoolean("onduty"),
                                 employeeType = (EmployeeObj.EmployeeType)reader.GetInt32(5),
+                                dims = JsonConvert.DeserializeObject<Dictionary<string, object>>(reader.GetString("dims")),
                             });
                         }
                     }
@@ -126,19 +124,23 @@ public class SqlServerExecutorTests
         {
             return SqlDbType.Bit;
         }
-        else if (parameterType == typeof(string))
+
+        if (parameterType == typeof(string))
         {
             return SqlDbType.NVarChar;
         }
-        else if (parameterType == typeof(Int32))
+
+        if (parameterType == typeof(int))
         {
             return SqlDbType.Int;
         }
-        else if (parameterType == typeof(decimal))
+
+        if (parameterType == typeof(decimal))
         {
             return SqlDbType.Decimal;
         }
-        else if (parameterType == typeof(DateTime))
+
+        if (parameterType == typeof(DateTime))
         {
             return SqlDbType.DateTime;
         }
@@ -147,7 +149,7 @@ public class SqlServerExecutorTests
     }
 
     [TestCleanup]
-    public async Task CleanupMongo()
+    public async Task Cleanup()
     {
         if (_container != null)
         {
@@ -158,6 +160,43 @@ public class SqlServerExecutorTests
     [TestMethod]
     public async Task EmployeeTestSuite()
     {
-        await Executors.EmployeeTestSuite.BasicTestSuite(_src, _list, _postgres);
+        await Executors.EmployeeTestSuite.BasicTestSuite(_src, _list, _sqlServer);
+    }
+
+    [TestMethod]
+    public async Task JsonColumn_Filter()
+    {
+        var syntax = _src.ParseFilter("dims.\"test\" eq 'value'");
+        var results = await _sqlServer(syntax);
+
+        Assert.AreEqual(2, results.records.Length);
+    }
+
+    [TestMethod]
+    public async Task JsonColumn_Sort()
+    {
+        var syntax = _src.ParseFilter("dims.\"test\".\"inner\" IS NOT NULL OR dims.\"test\" eq 'value'");
+        syntax.OrderBy = _src.ParseOrderBy("dims.\"test\".\"inner\"");
+        var results = await _sqlServer(syntax);
+
+        Assert.AreEqual(4, results.records.Length);
+    }
+
+    [TestMethod]
+    public async Task JsonColumn_Nested()
+    {
+        var syntax = _src.ParseFilter("dims.\"test\".\"inner\" eq 'value'");
+        var results = await _sqlServer(syntax);
+
+        Assert.AreEqual(1, results.records.Length);
+    }
+
+    [TestMethod]
+    public async Task JsonColumn_Parsing()
+    {
+        var syntax = _src.ParseFilter("dims.\"=<>\\\"\" eq 'value'");
+        var results = await _sqlServer(syntax);
+
+        Assert.AreEqual(0, results.records.Length);
     }
 }

--- a/tests/Searchlight.Tests/Models/EmployeeObj.cs
+++ b/tests/Searchlight.Tests/Models/EmployeeObj.cs
@@ -37,6 +37,9 @@ public class EmployeeObj
     [BsonRepresentation(BsonType.Int32)]
     [SearchlightField(FieldType = typeof(int), EnumType = typeof(EmployeeType))]
     public EmployeeType employeeType { get; set; }
+    
+    [SearchlightField(FieldType = typeof(string), IsJson = true)]
+    public Dictionary<string, object> dims { get; set; }
 
     public static List<EmployeeObj> GetTestList()
     {
@@ -50,6 +53,7 @@ public class EmployeeObj
                 onduty = true,
                 paycheck = 1000.00m, 
                 employeeType = EmployeeType.FullTime,
+                dims = new Dictionary<string, object> { {"test <> test", "value"} }
             },
             new()
             {
@@ -59,6 +63,7 @@ public class EmployeeObj
                 onduty = true,
                 paycheck = 1000.00m,
                 employeeType = EmployeeType.PartTime,
+                dims = new Dictionary<string, object> { {"test", "value"} }
             },
             new()
             {
@@ -68,6 +73,7 @@ public class EmployeeObj
                 onduty = false,
                 paycheck = 800.0m,
                 employeeType = EmployeeType.Contract,
+                dims = new Dictionary<string, object> { {"test", "value"} }
             },
             new()
             {
@@ -77,6 +83,7 @@ public class EmployeeObj
                 onduty = false,
                 paycheck = 1200.0m,
                 employeeType = EmployeeType.FullTime,
+                dims = new Dictionary<string, object>{{"test", new Dictionary<string, object>{{"inner", "balue"}}}}
             },
             new()
             {
@@ -86,6 +93,7 @@ public class EmployeeObj
                 onduty = true,
                 paycheck = 1000.00m,
                 employeeType = EmployeeType.FullTime,
+                dims = new Dictionary<string, object>{{"test", new Dictionary<string, object>{{"inner", "value"}}}}
             },
             new()
             {

--- a/tests/Searchlight.Tests/SqlExecutorTests.cs
+++ b/tests/Searchlight.Tests/SqlExecutorTests.cs
@@ -224,13 +224,13 @@ namespace Searchlight.Tests
             Assert.AreEqual(123456789123456, sql.Parameters["@p1"]);
 
             // Test the guid
-            query = _source.ParseFilter(String.Format("colguid eq '{0}'", Guid.Empty.ToString()));
+            query = _source.ParseFilter(string.Format("colguid eq '{0}'", Guid.Empty.ToString()));
             sql = query.ToSqlServerCommand();
             Assert.AreEqual("colGuid = @p1", sql.WhereClause.ToString());
             Assert.AreEqual(Guid.Empty, sql.Parameters["@p1"]);
 
             // Test the nullable guid
-            query = _source.ParseFilter(String.Format("colNullableGuid is null or colNullableGuid = '{0}'",
+            query = _source.ParseFilter(string.Format("colNullableGuid is null or colNullableGuid = '{0}'",
                 Guid.Empty.ToString()));
             sql = query.ToSqlServerCommand();
             Assert.AreEqual("colNullableGuid IS NULL OR colNullableGuid = @p1", sql.WhereClause.ToString());

--- a/tests/Searchlight.Tests/TokenizerTests.cs
+++ b/tests/Searchlight.Tests/TokenizerTests.cs
@@ -23,7 +23,7 @@ namespace Searchlight.Tests
         {
             // Parse a date time pattern
             string date = DateTime.UtcNow.ToString("yyyy-MM-dd");
-            string filters = String.Format("EffectiveDate > '{0}' OR MaintenanceDate > '{0}' OR TotalSalesEffDate > '{0}' OR SalesEffDate > '{0}' OR UseEffDate > '{0}'", date);
+            string filters = string.Format("EffectiveDate > '{0}' OR MaintenanceDate > '{0}' OR TotalSalesEffDate > '{0}' OR SalesEffDate > '{0}' OR UseEffDate > '{0}'", date);
             var list = Tokenizer.GenerateTokens(filters).TokenQueue.ToList();
             Assert.AreEqual(19, list.Count);
             Assert.AreEqual("EffectiveDate", list[0].Value);


### PR DESCRIPTION
# What changed?
- `SearchlightField`
    - Add `IsJson` property
- `DataSoure`
  - Use `ColumnInfo` for `WithRenamingColumn` to simplify params
- `ColumnInfo`
    - Add `IsJson` property
- `SyntaxParser`
    - Check for JSON keys in double quotes
    - Allow weird characters inside of JSON keys
    - Check for unterminated JSON keys
- `BaseClause`
    - Add `JsonKeys` array to allow nested filtering
    - Add `ColumnInfo`, almost all inheritors need it
- `SortInfo`
    - Add `JsonKeys` array to allow nested sorting
- `SqlExecutor`
    - Update all column names to check if a normal or JSON value need to be used
- `SqlServerExecutorTests`
    - Add new tests for JSON
    - Add new JSON column for testing
    - General cleanup
- `EmployeeObj`
    - Add new fields for tests
- `StringConstants`
    - Add required constants for tokenizer, double quotes and dot
- `UnterminatedJsonKey`
  - New exception for when JSON key is improperly quoted