### PR TITLE
Use Enum Member Values

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/tests/Searchlight.Tests/Searchlight.Tests.csproj
+++ b/tests/Searchlight.Tests/Searchlight.Tests.csproj
@@ -21,10 +21,10 @@
     </PackageReference>
     <PackageReference Include="MySql.Data" Version="8.1.0" />
     <PackageReference Include="Npgsql" Version="7.0.4" />
-    <PackageReference Include="Testcontainers" Version="3.4.0" />
-    <PackageReference Include="Testcontainers.MsSql" Version="3.4.0" />
-    <PackageReference Include="Testcontainers.MySql" Version="3.4.0" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="3.4.0" />
+    <PackageReference Include="Testcontainers" Version="4.2.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.2.0" />
+    <PackageReference Include="Testcontainers.MySql" Version="4.2.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Use EnumMember values when available as the expected query values. When EnunMember is present, report that value in error messages instead of underlying enum name